### PR TITLE
[subschema] Support nulls and booleans

### DIFF
--- a/modules/subschema/src/main/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/package.scala
+++ b/modules/subschema/src/main/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/package.scala
@@ -1,9 +1,11 @@
 package com.snowplowanalytics.iglu.schemaddl.jsonschema.subschema
 
 import com.snowplowanalytics.iglu.schemaddl.jsonschema.Schema
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.properties.CommonProperties._
 import com.snowplowanalytics.iglu.schemaddl.jsonschema.properties.CommonProperties.Type._
-import dregex.Regex
 
+import dregex.Regex
+import io.circe.Json
 
 package object subschema {
 
@@ -12,9 +14,11 @@ package object subschema {
 
   def canonicalize(s: Schema): Schema =
     s match {
-      case s if s.`type` == Some(Integer) => s.copy(`type` = Some(Number))
-      case s if s.`type` == Some(Number)  => s
-      case s if s.`type` == Some(String)  => s
+      case s if s.`type`.contains(Null)    => s
+      case s if s.`type`.contains(Boolean) => s.copy(`type` = None, `enum` = Some(Enum(List(Json.True, Json.False))))
+      case s if s.`type`.contains(Integer) => s.copy(`type` = Some(Number))
+      case s if s.`type`.contains(Number)  => s
+      case s if s.`type`.contains(String)  => s
       case _ => s
     }
 
@@ -22,8 +26,8 @@ package object subschema {
   def simplify(s: Schema): Schema = s
 
   def isSubType(s1: Schema, s2: Schema): Compatibility = (s1, s2) match {
-    case (s1, s2) if s1.`type` == Some(Number) && s1.`type` == s2.`type` => isNumberSubType(s1, s2)
-    case (s1, s2) if s1.`type` == Some(String) && s1.`type` == s2.`type` => isStringSubType(s1, s2)
+    case (s1, s2) if s1.`type`.contains(Number) && s1.`type` == s2.`type` => isNumberSubType(s1, s2)
+    case (s1, s2) if s1.`type`.contains(String) && s1.`type` == s2.`type` => isStringSubType(s1, s2)
     case _ => Undecidable
   }
 

--- a/modules/subschema/src/test/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/BooleanSpec.scala
+++ b/modules/subschema/src/test/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/BooleanSpec.scala
@@ -1,0 +1,33 @@
+package com.snowplowanalytics.iglu.schemaddl.jsonschema.subschema
+
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.Schema
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.properties.CommonProperties._
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.properties.CommonProperties.Type._
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.subschema.subschema._
+import io.circe.Json
+import org.specs2.Specification
+
+
+class BooleanSpec extends Specification with org.specs2.specification.Tables { def is = s2"""
+  Number schema ranges
+  ${
+    "s1enum"                | "s2enum"                | "result"     |>
+    Some(List(true))        ! Some(List(true, false)) ! Compatible   |
+    Some(List(true, false)) ! Some(List(true))        ! Incompatible |
+    None                    ! Some(List(false))       ! Incompatible |
+    Some(List(true))        ! None                    ! Compatible   |
+    None                    ! None                    ! Compatible   |
+    { (a, b, c) =>
+      val s1 = Schema.empty.copy(
+        `type` = Some(Boolean),
+        `enum` = a.map(xe => Enum(xe.map(Json.fromBoolean(_))))
+      )
+      val s2 = Schema.empty.copy(
+        `type` = Some(Boolean),
+        `enum` = b.map(xe => Enum(xe.map(Json.fromBoolean(_))))
+      )
+
+      isSubSchema(s1, s2) mustEqual c
+    }
+  }"""
+}

--- a/modules/subschema/src/test/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/NullSpec.scala
+++ b/modules/subschema/src/test/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/NullSpec.scala
@@ -1,0 +1,21 @@
+package com.snowplowanalytics.iglu.schemaddl.jsonschema.subschema
+
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.Schema
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.properties.CommonProperties.Type._
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.subschema.subschema._
+import org.specs2.Specification
+
+
+class NullSpec extends Specification {
+  def is =
+    s2"""
+      two schemas that allow only the null value are subtypes of each other $e1
+    """
+
+  def e1 = {
+    val s1 = Schema.empty.copy(`type` = Some(Null))
+    val s2 = Schema.empty.copy(`type` = Some(Null))
+
+    isSubSchema(s1, s2) mustEqual Compatible
+  }
+}


### PR DESCRIPTION
~~This one is really simple, so I bundled 2 together. Will add tests when I get to the other tickets that implement the actual subtype checking~~
Actually bundled canonicalization, simplification and subtype check for both nulls and boolean in one single PR, since the only two interesting things are canonicalization and subtype checking for booleans

Implements XP-1137, XP-1138, XP-1149, XP-1150