### PR TITLE
[XP-1143] Canonicalize objects

### DIFF
--- a/modules/subschema/src/main/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/package.scala
+++ b/modules/subschema/src/main/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/package.scala
@@ -119,7 +119,14 @@ package object subschema {
       )
     )
 
-    if (p1.isSubsetOf(p2) && pl1.isSubsetOf(pl2))
+    val compatibleFormat: Boolean =
+      (s1.format, s2.format) match {
+        case (Some(f1), Some(f2)) if f1 == f2 => true
+        case (_, None) => true
+        case _ => false
+      }
+
+    if (p1.isSubsetOf(p2) && pl1.isSubsetOf(pl2) && compatibleFormat)
       Compatible
     else
       Incompatible

--- a/modules/subschema/src/main/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/package.scala
+++ b/modules/subschema/src/main/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/package.scala
@@ -37,6 +37,7 @@ package object subschema {
     if (s.`enum`.isDefined) s else s.copy(`enum` = Some(Enum(List(Json.True, Json.False))))
 
   def canonicalizeEnum(s: Schema): Schema = {
+    // enum values are plain JSON values, not schemas
     val typeValue: Json => (Type, Option[Json]) =
       _.fold(
         jsonNull    = Null -> None,

--- a/modules/subschema/src/test/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/NumbersSpec.scala
+++ b/modules/subschema/src/test/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/NumbersSpec.scala
@@ -9,29 +9,32 @@ import com.snowplowanalytics.iglu.schemaddl.jsonschema.subschema.subschema._
 
 
 class NumbersSpec extends Specification with org.specs2.specification.Tables { def is = s2"""
-  Number schema ranges
-  ${
-     "s1min" | "s1max" | "s2max" | "s2max" | "result" |>
-     None    ! None    ! None    ! None    ! Compatible     |
-     Some(1) ! Some(1) ! Some(0) ! Some(2) ! Compatible     |
-     Some(0) ! Some(1) ! Some(1) ! Some(1) ! Incompatible   |
-     Some(0) ! None    ! Some(1) ! Some(1) ! Incompatible   |
-     None    ! Some(1) ! Some(1) ! Some(1) ! Incompatible   |
-     Some(1) ! Some(1) ! None    ! None    ! Compatible     |
-     None    ! None    ! Some(1) ! Some(1) ! Incompatible   |
-     { (a, b, c, d, e) => {
+  Number schema ranges ${
+     "s1Type" | "s2Type"  | "s1min"          | "s1max"          | "s2max"   | "s2max"   | "result"       |>
+     Number   ! Number    ! None             ! None             ! None      ! None      ! Compatible     |
+     Number   ! Number    ! Some(1.0)        ! Some(1.0)        ! Some(0.0) ! Some(2.0) ! Compatible     |
+     Number   ! Number    ! Some(0.0)        ! Some(1.0)        ! Some(1.0) ! Some(1.0) ! Incompatible   |
+     Number   ! Number    ! Some(0.0)        ! None             ! Some(1.0) ! Some(1.0) ! Incompatible   |
+     Number   ! Number    ! None             ! Some(1.0)        ! Some(1.0) ! Some(1.0) ! Incompatible   |
+     Number   ! Number    ! Some(1.0)        ! Some(1.0)        ! None      ! None      ! Compatible     |
+     Number   ! Number    ! None             ! None             ! Some(1.0) ! Some(1.0) ! Incompatible   |
+     Number   ! Integer   ! None             ! None             ! None      ! None      ! Incompatible   |
+     Integer  ! Number    ! None             ! None             ! None      ! None      ! Compatible     |
+     Integer  ! Number    ! Some(1.toDouble) ! Some(2.toDouble) ! Some(0.9) ! Some(2.1) ! Compatible     |
+     Integer  ! Integer   ! None             ! None             ! None      ! None      ! Compatible     |
+     { (a, b, c, d, e, f, g) => {
        val s1 = Schema.empty.copy(
-         `type`=Some(Number),
-         minimum=a.map(Minimum.NumberMinimum(_)),
-         maximum=b.map(Maximum.NumberMaximum(_))
-       )
-       val s2 = Schema.empty.copy(
-         `type`=Some(Number),
+         `type`=Some(a),
          minimum=c.map(Minimum.NumberMinimum(_)),
          maximum=d.map(Maximum.NumberMaximum(_))
        )
+       val s2 = Schema.empty.copy(
+         `type`=Some(b),
+         minimum=e.map(Minimum.NumberMinimum(_)),
+         maximum=f.map(Maximum.NumberMaximum(_))
+       )
 
-       isSubSchema(s1, s2) mustEqual e
+       isSubSchema(s1, s2) mustEqual g
      }}
    }"""
 }

--- a/modules/subschema/src/test/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/ObjectSpec.scala
+++ b/modules/subschema/src/test/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/ObjectSpec.scala
@@ -52,6 +52,28 @@ class ObjectSpec extends Specification with org.specs2.specification.Tables {
     additionalProperties = Some(AdditionalPropertiesAllowed(false))
   )
 
+  val s7 = Schema.empty.copy(
+    `type` = Some(Object),
+    properties = Some(Properties(Map(
+      "a" -> Schema.empty.copy(`type` = Some(Boolean))
+    ))),
+    patternProperties = Some(PatternProperties(Map(
+      "a.*" -> Schema.empty.copy(`type` = Some(String))
+    ))),
+    required = Some(Required(List("a"))),
+    additionalProperties = Some(AdditionalPropertiesAllowed(false))
+  )
+
+  val s8 = Schema.empty.copy(
+    `type` = Some(Object),
+    properties = Some(Properties(Map(
+      "a" -> Schema.empty.copy(`type` = Some(Boolean)),
+      "ab" -> Schema.empty.copy(`type` = Some(String))
+    ))),
+    required = Some(Required(List("a", "b"))),
+    additionalProperties = Some(AdditionalPropertiesAllowed(false))
+  )
+
   def is =
     s2"""
       Objects
@@ -66,6 +88,11 @@ class ObjectSpec extends Specification with org.specs2.specification.Tables {
         s5   ! s4   ! Compatible   |
         s4   ! s5   ! Incompatible | // interesting...
         s6   ! s5   ! Compatible   |
+        s7   ! s4   ! Compatible   |
+        s7   ! s5   ! Compatible   |
+        s7   ! s6   ! Incompatible |
+        s7   ! s7   ! Compatible   |
+        s8   ! s7   ! Compatible   |
         { (s1, s2, result) => isSubSchema(s1, s2) mustEqual result }
       }
     """

--- a/modules/subschema/src/test/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/ObjectSpec.scala
+++ b/modules/subschema/src/test/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/ObjectSpec.scala
@@ -1,0 +1,72 @@
+package com.snowplowanalytics.iglu.schemaddl.jsonschema.subschema
+
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.Schema
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.properties.CommonProperties.Type._
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.properties.ObjectProperty.AdditionalProperties.AdditionalPropertiesAllowed
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.properties.ObjectProperty._
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.subschema.subschema._
+import org.specs2.Specification
+
+
+class ObjectSpec extends Specification with org.specs2.specification.Tables {
+
+  val s1 = Schema.empty.copy(`type` = Some(Object))
+
+  val s2 = Schema.empty.copy(
+    `type` = Some(Object),
+    properties = Some(Properties(Map(
+      "a" -> any
+    )))
+  )
+
+  val s3 = Schema.empty.copy(
+    `type` = Some(Object),
+    properties = Some(Properties(Map(
+      "a" -> Schema.empty.copy(`type` = Some(Boolean))
+    )))
+  )
+
+  val s4 = Schema.empty.copy(
+    `type` = Some(Object),
+    properties = Some(Properties(Map(
+      "a" -> Schema.empty.copy(`type` = Some(Boolean))
+    ))),
+    required = Some(Required(List("a"))),
+  )
+
+  val s5 = Schema.empty.copy(
+    `type` = Some(Object),
+    properties = Some(Properties(Map(
+      "a" -> Schema.empty.copy(`type` = Some(Boolean)),
+      "b" -> Schema.empty.copy(`type` = Some(String)),
+    ))),
+    required = Some(Required(List("a"))),
+  )
+
+  val s6 = Schema.empty.copy(
+    `type` = Some(Object),
+    properties = Some(Properties(Map(
+      "a" -> Schema.empty.copy(`type` = Some(Boolean))
+    ))),
+    required = Some(Required(List("a"))),
+    additionalProperties = Some(AdditionalPropertiesAllowed(false))
+  )
+
+  def is =
+    s2"""
+      Objects
+      ${
+        "s1" | "s2" | "result"     |>
+        s1   ! s1   ! Compatible   |
+        s2   ! s2   ! Compatible   |
+        s3   ! s2   ! Compatible   |
+        s2   ! s3   ! Incompatible |
+        s3   ! s4   ! Incompatible |
+        s4   ! s3   ! Compatible   |
+        s5   ! s4   ! Compatible   |
+        s4   ! s5   ! Incompatible | // interesting...
+        s6   ! s5   ! Compatible   |
+        { (s1, s2, result) => isSubSchema(s1, s2) mustEqual result }
+      }
+    """
+}

--- a/modules/subschema/src/test/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/StringsSpec.scala
+++ b/modules/subschema/src/test/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/StringsSpec.scala
@@ -11,32 +11,38 @@ import com.snowplowanalytics.iglu.schemaddl.jsonschema.properties.StringProperty
 class StringsSpec extends Specification with org.specs2.specification.Tables { def is = s2"""
   Strings
   ${
-     "s1min" | "s1max" | "s2max" | "s2max" | "p1" | "p2" | "result" |>
-     None    ! None    ! None    ! None    ! None ! None ! Compatible     |
-     Some(1) ! Some(1) ! Some(0) ! Some(2) ! None ! None ! Compatible     |
-     Some(0) ! Some(1) ! Some(1) ! Some(1) ! None ! None ! Incompatible   |
-     Some(0) ! None    ! Some(1) ! Some(1) ! None ! None ! Incompatible   |
-     None    ! Some(1) ! Some(1) ! Some(1) ! None ! None ! Incompatible   |
-     Some(1) ! Some(1) ! None    ! None    ! None ! None ! Compatible     |
-     None    ! None    ! None    ! None    ! Some("^.*$") ! Some(".*") ! Compatible |
-     None    ! None    ! None    ! None    ! Some("[def]*") ! Some("[^abc]*") ! Compatible |
-     None    ! None    ! None    ! None    ! None ! Some("[abc]*") ! Incompatible |
-     None    ! None    ! None    ! None    ! Some("a") ! Some("a|b|c") ! Compatible |
-     { (a, b, c, d, e, f, g) => {
+     "s1min" | "s1max" | "s2max" | "s2max" | "p1"           | "p2"            | "f1"         | "f2"         | "result"     |>
+     None    ! None    ! None    ! None    ! None           ! None            ! None         ! None         ! Compatible   |
+     Some(1) ! Some(1) ! Some(0) ! Some(2) ! None           ! None            ! None         ! None         ! Compatible   |
+     Some(0) ! Some(1) ! Some(1) ! Some(1) ! None           ! None            ! None         ! None         ! Incompatible |
+     Some(0) ! None    ! Some(1) ! Some(1) ! None           ! None            ! None         ! None         ! Incompatible |
+     None    ! Some(1) ! Some(1) ! Some(1) ! None           ! None            ! None         ! None         ! Incompatible |
+     Some(1) ! Some(1) ! None    ! None    ! None           ! None            ! None         ! None         ! Compatible   |
+     None    ! None    ! None    ! None    ! Some("^.*$")   ! Some(".*")      ! None         ! None         ! Compatible   |
+     None    ! None    ! None    ! None    ! Some("[def]*") ! Some("[^abc]*") ! None         ! None         ! Compatible   |
+     None    ! None    ! None    ! None    ! None           ! Some("[abc]*")  ! None         ! None         ! Incompatible |
+     None    ! None    ! None    ! None    ! Some("a")      ! Some("a|b|c")   ! None         ! None         ! Compatible   |
+     None    ! None    ! None    ! None    ! None           ! None            ! Some("ipv4") ! Some("ipv4") ! Compatible   |
+     None    ! None    ! None    ! None    ! None           ! None            ! Some("ipv4") ! None         ! Compatible   |
+     None    ! None    ! None    ! None    ! None           ! None            ! None         ! Some("ipv4") ! Incompatible |
+     None    ! None    ! None    ! None    ! None           ! None            ! Some("uri")  ! Some("ipv4") ! Incompatible |
+     { (a, b, c, d, e, f, g, h, i) => {
        val s1 = Schema.empty.copy(
          `type`=Some(String),
          pattern=e.map(Pattern(_)),
          minLength=a.map(MinLength(_)),
-         maxLength=b.map(MaxLength(_))
+         maxLength=b.map(MaxLength(_)),
+         format=g.map(Format.fromString(_))
        )
        val s2 = Schema.empty.copy(
          `type`=Some(String),
          pattern=f.map(Pattern(_)),
          minLength=c.map(MinLength(_)),
-         maxLength=d.map(MaxLength(_))
+         maxLength=d.map(MaxLength(_)),
+         format=h.map(Format.fromString(_))
        )
 
-       isSubSchema(s1, s2) mustEqual g
+       isSubSchema(s1, s2) mustEqual i
      }}
    }"""
 }


### PR DESCRIPTION
I thought a lot about this one, and the critical issue I found while implementing the canonicalization as described in the paper is that I wasn't able to rewrite `additionalProperties` (when it's a schema) into a `patternProperty` that applies to every property that is not matched any other `patternProperty` already:
![Screenshot 2023-03-01 alle 18 24 53](https://user-images.githubusercontent.com/17480403/222215968-94ca62f1-9a42-4a1e-ab24-15ff32173230.png)
In particular, while I could compile a regex that matches anything except what gets already matched by patternProperties (including properties rewritten to patternProperties already) I couldn’t find a way to turn the resulting synthetic regex back into a string.
So I was able to do something like `”.*” diff “(abc|def)”`, but the result is a DFA that cannot be turned into the string representing the regex.  So what I’m going to do is that I’ll pretend this canonicalization rule doesn’t exist for the time being, and we will see if I’ll be able to enforce the rule later when doing the subType check instead. 


Will also leave out the rules that deal with overlapping `patternProperties` (there is a bit about that in the rule above too), as those look like a mine field and probably not even required for our use case (at least to start with):
![Screenshot 2023-03-01 alle 18 25 12](https://user-images.githubusercontent.com/17480403/222216305-081a809e-fbfe-4c22-9812-f3480b4443bd.png)


Finally, rules around dependencies don’t apply as our json validation library doesn’t even parse the `dependencies` keyword:
![Screenshot 2023-03-01 alle 18 25 05](https://user-images.githubusercontent.com/17480403/222216395-9bc40f92-87c0-484b-b759-4315c134cbea.png)
