### PR TITLE
XP-1154 subtype check array

### DIFF
--- a/modules/subschema/src/test/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/ArraySpec.scala
+++ b/modules/subschema/src/test/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/ArraySpec.scala
@@ -1,0 +1,77 @@
+package com.snowplowanalytics.iglu.schemaddl.jsonschema.subschema
+
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.Schema
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.properties.ArrayProperty.AdditionalItems._
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.properties.ArrayProperty.Items._
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.properties.ArrayProperty._
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.properties.CommonProperties.Type._
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.subschema.subschema._
+import org.specs2.Specification
+
+
+class ArraySpec extends Specification with org.specs2.specification.Tables {
+
+  val s1 = Schema.empty.copy(`type` = Some(Array))
+
+  val s2 = Schema.empty.copy(
+    `type` = Some(Array),
+    items = Some(ListItems(Schema.empty.copy(`type` = Some(Integer))))
+  )
+
+  val s3 = Schema.empty.copy(
+    `type` = Some(Array),
+    items = Some(ListItems(Schema.empty.copy(`type` = Some(Number))))
+  )
+
+  val s4 = Schema.empty.copy(
+    `type` = Some(Array),
+    items = Some(ListItems(Schema.empty.copy(`type` = Some(Number)))),
+    minItems = Some(MinItems(3)),
+    maxItems = Some(MaxItems(10))
+  )
+
+  val s5 = Schema.empty.copy(
+    `type` = Some(Array),
+    items = Some(TupleItems(List(
+      Schema.empty.copy(`type` = Some(Number))
+    ))),
+    additionalItems = Some(AdditionalItemsAllowed(true))
+  )
+
+  val s6 = Schema.empty.copy(
+    `type` = Some(Array),
+    items = Some(TupleItems(List(
+      Schema.empty.copy(`type` = Some(Number)),
+      Schema.empty.copy(`type` = Some(String)),
+    ))),
+    additionalItems = Some(AdditionalItemsAllowed(true))
+  )
+
+  val s7 = Schema.empty.copy(
+    `type` = Some(Array),
+    items = Some(TupleItems(List(
+      Schema.empty.copy(`type` = Some(Number))
+    ))),
+    additionalItems = Some(AdditionalItemsSchema(Schema.empty.copy(`type` = Some(String))))
+  )
+
+  def is =
+    s2"""
+      Arrays
+      ${
+        "s1" | "s2" | "result"     |>
+        s1   ! s2   ! Incompatible |
+        s2   ! s1   ! Compatible   |
+        s2   ! s2   ! Compatible   |
+        s2   ! s3   ! Compatible   |
+        s3   ! s2   ! Incompatible |
+        s3   ! s4   ! Incompatible |
+        s4   ! s3   ! Compatible   |
+        s5   ! s6   ! Incompatible |
+        s6   ! s5   ! Compatible   |
+        s6   ! s7   ! Incompatible |
+        s7   ! s6   ! Compatible   |
+        { (s1, s2, result) => isSubSchema(s1, s2) mustEqual result }
+      }
+    """
+}


### PR DESCRIPTION
This PR implements the following rule:
![image](https://user-images.githubusercontent.com/17480403/224955704-d78b3add-cae5-45dc-81be-166434d73c8c.png)
Three things to note:
- `uniqueItems` is not part of the AST, so that isn't taken into account. We should probably stick a subtask into the backlog and take care of that later. 
- this PR contains a semigroup for `Compatibility`, which is used to combine lists of `Compatibility` into a single result (used for both arrays and also objects where we recursively do a subschema check on items/properties one after the other)
- the most important rule might be a little hard to digest, so I'll try to visualize the following explanation in words as it comes from the paper: `the schema of every item specified in the former needs to be a subschema of the corresponding specification in the latter. If a schema is not explicitly provided, the schema provided by additionalItems is used`

Let's say schema1 looks like 
```
{ 
  "type": "array", 
  "items": [ {"type": "string", "maxLength": 10}, {"type": "boolean"} ], 
  "additionalItems": {"type": "integer"}
}
```
and schema2 looks like
```
{ 
  "type": "array", 
  "items": [ {"type": "string"}, {"type": "boolean"}, {"type": "number"}], 
  "additionalItems": {"type": "number"}
}
```
(remember that `items` once canonicalized is always used to represent `tuples`, not a heterogeneous array)
Then we need to compare items at the same index, and if the two arrays of items aren't the same size we need to compare against `additionalItems`. Plus we got to compare one `additionalItems` to the other. So in order to do that, the two arrays of schemas to compare become something like
```
[j1,  j2,  (ai1), ai1]
 <:   <:    <:     <:
[k1,  k2,   k3,   ai2]
```
The technical implementation to get two arrays of the same size is described in the rule: we take the max between the two lenghts of the `items` arrays, adding 1 to compare `additionalItems` schemas to each other, and pad both arrays on the right with the respective `additionalItems` schema to that number
