### PR TITLE
XP-1344 + XP-1356 Canonicalise list of types and simplify enums

### DIFF
--- a/modules/subschema/src/test/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/AnyOfSpec.scala
+++ b/modules/subschema/src/test/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/AnyOfSpec.scala
@@ -1,0 +1,55 @@
+package com.snowplowanalytics.iglu.schemaddl.jsonschema.subschema
+
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.Schema
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.properties.CommonProperties.{AnyOf, Enum}
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.properties.CommonProperties.Type._
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.subschema.subschema._
+import io.circe.Json
+import org.specs2.Specification
+
+
+class AnyOfSpec extends Specification with org.specs2.specification.Tables {
+
+  val s1 = Schema.empty.copy(
+    anyOf = Some(AnyOf(List(
+      Schema.empty.copy(`type` = Some(String))
+    )))
+  )
+
+  // Optionals using anyOf
+  val s2 = Schema.empty.copy(
+    anyOf = Some(AnyOf(List(
+      Schema.empty.copy(`type` = Some(String)),
+      Schema.empty.copy(`type` = Some(Null)),
+    )))
+  )
+
+  // Optionals with union of types
+  val s3 = Schema.empty.copy(
+    `type` = Some(Union(Set(String, Null)))
+  )
+
+  // Heterogenous enums
+  val s4 = Schema.empty.copy(
+    `enum` = Some(Enum(List(Json.fromString("some_string"), Json.Null)))
+  )
+
+  def is =
+    s2"""
+      AnyOf
+      ${
+        "s1" | "s2" | "result"     |>
+        s1   ! s1   ! Compatible   |
+        s1   ! s2   ! Compatible   |
+        s1   ! s3   ! Compatible   |
+        s2   ! s1   ! Incompatible |
+        s3   ! s1   ! Incompatible |
+        s3   ! s2   ! Compatible   |
+        s2   ! s3   ! Compatible   |
+        s4   ! s1   ! Incompatible |
+        s4   ! s2   ! Compatible   |
+        s4   ! s3   ! Compatible   |
+        { (s1, s2, result) => isSubSchema(s1, s2) mustEqual result }
+      }
+    """
+}

--- a/modules/subschema/src/test/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/EnumSpec.scala
+++ b/modules/subschema/src/test/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/EnumSpec.scala
@@ -1,10 +1,16 @@
 package com.snowplowanalytics.iglu.schemaddl.jsonschema.subschema
 
 import com.snowplowanalytics.iglu.schemaddl.jsonschema.Schema
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.properties.ArrayProperty.Items._
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.properties.ArrayProperty._
 import com.snowplowanalytics.iglu.schemaddl.jsonschema.properties.CommonProperties._
 import com.snowplowanalytics.iglu.schemaddl.jsonschema.properties.CommonProperties.Type._
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.properties.NumberProperty.Maximum._
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.properties.NumberProperty.Minimum._
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.properties.ObjectProperty.AdditionalProperties._
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.properties.ObjectProperty._
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.properties.StringProperty._
 import com.snowplowanalytics.iglu.schemaddl.jsonschema.subschema.subschema._
-
 import io.circe.Json
 import org.specs2.Specification
 
@@ -13,6 +19,13 @@ class EnumSpec extends Specification {
   def is =
     s2"""
       heterogeneous enum gets canonicalized into a disjunction of multiple homogeneous enums $e1
+      non-boolean multi-valued enum gets simplified to anyOf of single-valued enums $e2
+      null single-valued enum gets simplified to schema with type but no enum $e3
+      string single-valued enum gets simplified to schema with type and pattern $e4
+      integer single-valued enum gets simplified to schema with type, minimum and maximum $e5
+      number single-valued enum gets simplified to schema with type, minimum and maximum $e6
+      array single-valued enum gets simplified to schema with type, minItems, maxItems and items $e7
+      object single-valued enum gets simplified to schema with type, required, additionalProperties and properties $e8
     """
 
   def e1 = {
@@ -41,5 +54,100 @@ class EnumSpec extends Specification {
       Schema.empty.copy(`type` = Some(Object), `enum` = Some(Enum(List(Json.obj())))),
       Schema.empty.copy(`type` = Some(Array), `enum` = Some(Enum(List(Json.arr()))))
     ))
+  }
+
+  def e2 = {
+    val input = Schema.empty.copy(
+      `type` = Some(String),
+      `enum` = Some(Enum(List(Json.fromString("a"), Json.fromString("b"))))
+    )
+
+    val result = simplify(input)
+
+    result.anyOf.map(_.value.length) mustEqual input.`enum`.map(_.value.length)
+  }
+
+  def e3 = {
+    val input = Schema.empty.copy(
+      `type` = Some(Null),
+      `enum` = Some(Enum(List(Json.Null)))
+    )
+
+    simplify(input) mustEqual Schema.empty.copy(`type` = Some(Null))
+  }
+
+  def e4 = {
+    val input = Schema.empty.copy(
+      `type` = Some(String),
+      `enum` = Some(Enum(List(Json.fromString("a"))))
+    )
+
+    simplify(input) mustEqual Schema.empty.copy(`type` = Some(String), pattern = Some(Pattern("^a$")))
+  }
+
+  def e5 = {
+    val input = Schema.empty.copy(
+      `type` = Some(Integer),
+      `enum` = Some(Enum(List(Json.fromInt(1))))
+    )
+
+    simplify(input) mustEqual Schema.empty.copy(
+      `type` = Some(Integer),
+      minimum = Some(IntegerMinimum(1)),
+      maximum = Some(IntegerMaximum(1))
+    )
+  }
+
+  def e6 = {
+    val input = Schema.empty.copy(
+      `type` = Some(Number),
+      `enum` = Some(Enum(List(Json.fromBigDecimal(1.0))))
+    )
+
+    simplify(input) mustEqual Schema.empty.copy(
+      `type` = Some(Number),
+      minimum = Some(NumberMinimum(1.0)),
+      maximum = Some(NumberMaximum(1.0))
+    )
+  }
+
+  def e7 = {
+    val input = Schema.empty.copy(
+      `type` = Some(Array),
+      `enum` = Some(Enum(List(Json.arr(Json.fromInt(1)))))
+    )
+
+    simplify(input) mustEqual Schema.empty.copy(
+      `type` = Some(Array),
+      minItems = Some(MinItems(1)),
+      maxItems = Some(MaxItems(1)),
+      items = Some(TupleItems(List(
+        Schema.empty.copy(
+          `type` = Some(Number),
+          minimum = Some(NumberMinimum(1)),
+          maximum = Some(NumberMaximum(1))
+        )
+      )))
+    )
+  }
+
+  def e8 = {
+    val input = Schema.empty.copy(
+      `type` = Some(Object),
+      `enum` = Some(Enum(List(Json.obj("a" -> Json.fromInt(1)))))
+    )
+
+    simplify(input) mustEqual Schema.empty.copy(
+      `type` = Some(Object),
+      required = Some(Required(List("a"))),
+      additionalProperties = Some(AdditionalPropertiesSchema(Schema.empty.copy(not = Some(Not(Schema.empty))))),
+      properties = Some(Properties(Map(
+        "a" -> Schema.empty.copy(
+          `type` = Some(Number),
+          minimum = Some(NumberMinimum(1)),
+          maximum = Some(NumberMaximum(1))
+        )
+      )))
+    )
   }
 }


### PR DESCRIPTION
Two things here.
First one is canonicalization of list of types, quite trivial, it gets rewritten to anyOf:
![Screenshot 2023-03-16 alle 12 51 51](https://user-images.githubusercontent.com/17480403/225609285-e3f02683-6c51-452f-b5c8-1c2b00787401.png)
Second one is a bit more involved, but not difficult:
- first rule (non type-specific) simplifies enums with multiple values of the same type (e.g. `"enum": [1, 2, 3]`) rewriting to multiple schemas, each one accepting only one enum value, and combining them using anyOf:
![image](https://user-images.githubusercontent.com/17480403/225610061-f040684a-f2a8-4dc8-a96c-1477f0aa960f.png)
- following rules are type-specific and get rid of the enum keyword (except for booleans) rewriting strings to patterns, numbers to ranges that can contain just that value using minimum and maximum etc, to then leverage subtype check of those types that already checks those constructs:
![image](https://user-images.githubusercontent.com/17480403/225610716-d0253c39-8693-4e12-9127-cc50dcaab776.png)