### PR TITLE
[XP-1454] fix string with max length canonicalization

### DIFF
--- a/modules/subschema/src/main/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/package.scala
+++ b/modules/subschema/src/main/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/package.scala
@@ -173,7 +173,7 @@ package object subschema {
         case (Some(m1), Some(m2)) => s".{${m1.value},${m2.value}}"
         case (None, Some(m2))     => s".{0,${m2.value}}"
         case (Some(m1), None)     => s".{${m1.value},}"
-        case (None, None)         => s".*"
+        case (None, None)         => s".{0}"
       }
 
     val List(p1, pl1, p2, pl2) = Regex.compile(

--- a/modules/subschema/src/test/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/StringsSpec.scala
+++ b/modules/subschema/src/test/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/StringsSpec.scala
@@ -17,7 +17,7 @@ class StringsSpec extends Specification with org.specs2.specification.Tables { d
      Some(0) ! Some(1) ! Some(1) ! Some(1) ! None           ! None            ! None         ! None         ! Incompatible |
      Some(0) ! None    ! Some(1) ! Some(1) ! None           ! None            ! None         ! None         ! Incompatible |
      None    ! Some(1) ! Some(1) ! Some(1) ! None           ! None            ! None         ! None         ! Incompatible |
-     Some(1) ! Some(1) ! None    ! None    ! None           ! None            ! None         ! None         ! Compatible   |
+     Some(1) ! Some(1) ! None    ! None    ! None           ! None            ! None         ! None         ! Incompatible |
      None    ! None    ! None    ! None    ! Some("^.*$")   ! Some(".*")      ! None         ! None         ! Compatible   |
      None    ! None    ! None    ! None    ! Some("[def]*") ! Some("[^abc]*") ! None         ! None         ! Compatible   |
      None    ! None    ! None    ! None    ! None           ! Some("[abc]*")  ! None         ! None         ! Incompatible |


### PR DESCRIPTION
FYI @jamessnowplow, I also needed to change a test. It makes sense as `s1` is `'.{1,1}'` and `s2` `'.{0}'`, so `s1.subset(s2) == false`.

Note: Once this is merge we need to create another PR on the msc-backend to get the latest commit from the submodule so it will fix the issue.