### PR TITLE
[XP-1673] optimize subsetof condition on string subtype

### DIFF
--- a/modules/subschema/src/test/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/StringsSpec.scala
+++ b/modules/subschema/src/test/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/StringsSpec.scala
@@ -11,25 +11,27 @@ import com.snowplowanalytics.iglu.schemaddl.jsonschema.properties.StringProperty
 class StringsSpec extends Specification with org.specs2.specification.Tables { def is = s2"""
   Strings
   ${
-     "s1min" | "s1max" | "s2min" | "s2max" | "p1"           | "p2"            | "f1"         | "f2"         | "result"     |>
-     None    ! None    ! None    ! None    ! None           ! None            ! None         ! None         ! Compatible   |
-     Some(1) ! Some(1) ! Some(0) ! Some(2) ! None           ! None            ! None         ! None         ! Compatible   |
-     Some(0) ! Some(1) ! Some(1) ! Some(1) ! None           ! None            ! None         ! None         ! Incompatible |
-     Some(0) ! None    ! Some(1) ! Some(1) ! None           ! None            ! None         ! None         ! Incompatible |
-     None    ! Some(1) ! Some(1) ! Some(1) ! None           ! None            ! None         ! None         ! Incompatible |
-     Some(1) ! Some(1) ! None    ! None    ! None           ! None            ! None         ! None         ! Compatible   |
-     None    ! None    ! None    ! None    ! Some("^.*$")   ! Some(".*")      ! None         ! None         ! Compatible   |
-     None    ! None    ! None    ! None    ! Some("[def]*") ! Some("[^abc]*") ! None         ! None         ! Compatible   |
-     None    ! None    ! None    ! None    ! None           ! Some("[abc]*")  ! None         ! None         ! Incompatible |
-     None    ! None    ! None    ! None    ! Some("a")      ! Some("a|b|c")   ! None         ! None         ! Compatible   |
-     None    ! None    ! None    ! None    ! None           ! None            ! Some("ipv4") ! Some("ipv4") ! Compatible   |
-     None    ! None    ! None    ! None    ! None           ! None            ! Some("ipv4") ! None         ! Compatible   |
-     None    ! None    ! None    ! None    ! None           ! None            ! None         ! Some("ipv4") ! Incompatible |
-     None    ! None    ! None    ! None    ! None           ! None            ! Some("uri")  ! Some("ipv4") ! Incompatible |
-     None    ! Some(5) ! None    ! None    ! None           ! None            ! None         ! None         ! Compatible   |
-     None    ! None    ! None    ! Some(1) ! None           ! None            ! None         ! None         ! Incompatible |
-     None    ! None    ! None    ! Some(5) ! Some("< 5")    ! None            ! None         ! None         ! Compatible   |
-     None    ! None    ! None    ! Some(2) ! Some("> 2")    ! None            ! None         ! None         ! Incompatible |
+     "s1min"    | "s1max"    | "s2min"    | "s2max"    | "p1"           | "p2"            | "f1"         | "f2"         | "result"     |>
+     None       ! None       ! None       ! None       ! None           ! None            ! None         ! None         ! Compatible   |
+     None       ! Some(3000) ! None       ! Some(3000) ! None           ! None            ! None         ! None         ! Compatible   |
+     Some(3000) ! None       ! Some(3000) ! None       ! None           ! None            ! None         ! None         ! Compatible   |
+     Some(1)    ! Some(1)    ! Some(0)    ! Some(2)    ! None           ! None            ! None         ! None         ! Compatible   |
+     Some(0)    ! Some(1)    ! Some(1)    ! Some(1)    ! None           ! None            ! None         ! None         ! Incompatible |
+     Some(0)    ! None       ! Some(1)    ! Some(1)    ! None           ! None            ! None         ! None         ! Incompatible |
+     None       ! Some(1)    ! Some(1)    ! Some(1)    ! None           ! None            ! None         ! None         ! Incompatible |
+     Some(1)    ! Some(1)    ! None       ! None       ! None           ! None            ! None         ! None         ! Compatible   |
+     None       ! None       ! None       ! None       ! Some("^.*$")   ! Some(".*")      ! None         ! None         ! Compatible   |
+     None       ! None       ! None       ! None       ! Some("[def]*") ! Some("[^abc]*") ! None         ! None         ! Compatible   |
+     None       ! None       ! None       ! None       ! None           ! Some("[abc]*")  ! None         ! None         ! Incompatible |
+     None       ! None       ! None       ! None       ! Some("a")      ! Some("a|b|c")   ! None         ! None         ! Compatible   |
+     None       ! None       ! None       ! None       ! None           ! None            ! Some("ipv4") ! Some("ipv4") ! Compatible   |
+     None       ! None       ! None       ! None       ! None           ! None            ! Some("ipv4") ! None         ! Compatible   |
+     None       ! None       ! None       ! None       ! None           ! None            ! None         ! Some("ipv4") ! Incompatible |
+     None       ! None       ! None       ! None       ! None           ! None            ! Some("uri")  ! Some("ipv4") ! Incompatible |
+     None       ! Some(5)    ! None       ! None       ! None           ! None            ! None         ! None         ! Compatible   |
+     None       ! None       ! None       ! Some(1)    ! None           ! None            ! None         ! None         ! Incompatible |
+     None       ! None       ! None       ! Some(5)    ! Some("< 5")    ! None            ! None         ! None         ! Compatible   |
+     None       ! None       ! None       ! Some(2)    ! Some("> 2")    ! None            ! None         ! None         ! Incompatible |
      { (a, b, c, d, e, f, g, h, i) => {
        val s1 = Schema.empty.copy(
          `type`=Some(String),


### PR DESCRIPTION
Optimized the isStringSubType method to not call Regexp `isSubsetOf` method whenever it is possible as it is an expensive method when DFA states are high.

I will add a limit based on DFA states, so when n + m states exceeds that limit we will return Undecidable but I will make it in a separate PR, I will do some analytics on what are the times based on n + m that are acceptable and set that limit.