### PR TITLE
[XP-XXXX] Correctly identify enum subtype of non enum supertype

### DIFF
--- a/modules/subschema/src/main/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/package.scala
+++ b/modules/subschema/src/main/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/package.scala
@@ -150,7 +150,7 @@ package object subschema {
   def isSubType(s1: Schema, s2: Schema): Compatibility = (s1, s2) match {
     case (_, `any`)                                                        => Compatible
     case (`none`, _)                                                       => Compatible
-    case (s1, s2) if s2.anyOf.isDefined                                    => anyOfSubType(s1, s2)
+    case (s1, s2) if s1.anyOf.isDefined || s2.anyOf.isDefined              => anyOfSubType(s1, s2)
     case (s1, s2) if s1.`type`.contains(Null) && s1.`type` == s2.`type`    => Compatible
     case (s1, s2) if s1.`type`.contains(Boolean) && s1.`type` == s2.`type` => isBooleanSubType(s1, s2)
     case (s1, s2) if isNumber(s1) && isNumber(s2)                          => isNumberSubType(s1, s2)
@@ -351,6 +351,9 @@ package object subschema {
         combineAll(combineAnd)(h, t:_*)
       case (_, Some(AnyOf(ao2))) =>
         val h :: t = ao2.map(j => isSubType(s1, j))
+        combineAll(combineOr)(h, t:_*)
+      case (Some(AnyOf(ao1)), None) =>
+        val h :: t = ao1.map(j => isSubType(j, s2))
         combineAll(combineOr)(h, t:_*)
       case _ =>
         Undecidable

--- a/modules/subschema/src/main/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/package.scala
+++ b/modules/subschema/src/main/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/package.scala
@@ -349,7 +349,7 @@ package object subschema {
           combineAll(combineOr)(h, t:_*)
         })
         combineAll(combineAnd)(h, t:_*)
-      case (_, Some(AnyOf(ao2))) =>
+      case (None, Some(AnyOf(ao2))) =>
         val h :: t = ao2.map(j => isSubType(s1, j))
         combineAll(combineOr)(h, t:_*)
       case (Some(AnyOf(ao1)), None) =>

--- a/modules/subschema/src/test/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/AnyOfSpec.scala
+++ b/modules/subschema/src/test/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/subschema/AnyOfSpec.scala
@@ -57,6 +57,10 @@ class AnyOfSpec extends Specification with org.specs2.specification.Tables {
     `maxLength` = Some(StringProperty.MaxLength(5))
   )
 
+  val s9 = Schema.empty.copy(
+    `type` = Some(Integer),
+  )
+
   def is =
     s2"""
       AnyOf
@@ -74,6 +78,7 @@ class AnyOfSpec extends Specification with org.specs2.specification.Tables {
         s4   ! s3   ! Compatible   |
         s5   ! s6   ! Compatible   |
         s7   ! s8   ! Incompatible |
+        s6   ! s9   ! Compatible   |
         { (s1, s2, result) => isSubSchema(s1, s2) mustEqual result }
       }
     """


### PR DESCRIPTION
I was experimenting with  something like `{ type: string, enum: ["a", "b"] }` is subtype of `{ type: string }` and it wasn't working. I think this fixes it.